### PR TITLE
Simplify the example code

### DIFF
--- a/examples/components/main.go
+++ b/examples/components/main.go
@@ -4,20 +4,14 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/haleyrc/c4"
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
-		log.Println("error:", err)
-		os.Exit(1)
-	}
-}
+	ctx := context.Background()
 
-func run(ctx context.Context) error {
 	mainframeBankingSystem, _ := c4.NewSystem(ctx, "mainframeBankingSystem", c4.SystemArgs{
 		Name:        "Mainframe Banking System",
 		Description: "Stores all of the core banking information about customers, accounts, transactions, etc.",
@@ -217,8 +211,6 @@ func run(ctx context.Context) error {
 	)
 
 	if err := d.PlantUML(ctx, os.Stdout); err != nil {
-		return err
+		panic(err)
 	}
-
-	return nil
 }

--- a/examples/containers/main.go
+++ b/examples/containers/main.go
@@ -4,20 +4,14 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/haleyrc/c4"
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
-		log.Println("error:", err)
-		os.Exit(1)
-	}
-}
+	ctx := context.Background()
 
-func run(ctx context.Context) error {
 	personalBankingCustomer, _ := c4.NewPerson(ctx, "personalBankingCustomer", c4.PersonArgs{
 		Name:        "Personal Banking Customer",
 		Description: "A customer of the bank with personal bank accounts.",
@@ -168,8 +162,7 @@ func run(ctx context.Context) error {
 	)
 
 	if err := d.PlantUML(ctx, os.Stdout); err != nil {
-		return err
+		panic(err)
 	}
 
-	return nil
 }

--- a/examples/systems/main.go
+++ b/examples/systems/main.go
@@ -4,20 +4,14 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
 
 	"github.com/haleyrc/c4"
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
-		log.Println("error:", err)
-		os.Exit(1)
-	}
-}
+	ctx := context.Background()
 
-func run(ctx context.Context) error {
 	personalBankingCustomer, _ := c4.NewPerson(ctx, "personalBankingCustomer", c4.PersonArgs{
 		Name:        "Personal Banking Customer",
 		Description: "A customer of the bank with personal bank accounts.",
@@ -77,8 +71,6 @@ func run(ctx context.Context) error {
 	)
 
 	if err := d.PlantUML(ctx, os.Stdout); err != nil {
-		return err
+		panic(err)
 	}
-
-	return nil
 }


### PR DESCRIPTION
This commit simply removes an extra level of indirection that was originally added to make it easier to handle errors. Since the example code largely omits error handling for readability, this is no longer necessary.