### PR TITLE
fix: Print newline to the buffer instead of printing the buffer

### DIFF
--- a/diagram.go
+++ b/diagram.go
@@ -120,7 +120,7 @@ func (d *Diagram) writePreamble(ctx context.Context, buff *bytes.Buffer, title s
 	fmt.Fprintln(buff, "!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Deployment.puml")
 	fmt.Fprintln(buff)
 	fmt.Fprintln(buff, "WithoutPropertyHeader()")
-	fmt.Println(buff)
+	fmt.Fprintln(buff)
 	fmt.Fprintf(buff, "%s()\n", layout)
 	if d.sketch {
 		fmt.Fprintln(buff, `LAYOUT_AS_SKETCH()`)


### PR DESCRIPTION
This commit fixes an issue where rather than adding an extra blank line to the buffer while writing the preamble, we were instead printing the current contents of the buffer to stdout.

This didn't actually affect functionality, but we shouldn't print nonsense to the terminal and confuse users.